### PR TITLE
ci(build): update GitHub Actions workflow for Go build process

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,40 +5,44 @@ on:
     types: [published]
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
-    steps:
+    permissions:
+      contents: write
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.19
+          go-version: '1.23'
+          check-latest: true
         id: go
 
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Build
         run: |
-          hash=`git rev-list --tags --max-count=1`
-          version=`git describe --tags $hash`
+          hash=$(git rev-list --tags --max-count=1)
+          version=$(git describe --tags $hash)
           flag="-s -w -X main.version=$version"
           go mod tidy
-          GOOS=windows GOARCH=amd64   go build -ldflags "$flag" -o build/windows-amd64/jvms.exe
-          GOOS=windows GOARCH=386     go build -ldflags "$flag" -o build/windows-386/jvms.exe
+          GOOS=windows GOARCH=amd64 go build -ldflags "$flag" -o build/windows-amd64/jvms.exe
+          GOOS=windows GOARCH=386   go build -ldflags "$flag" -o build/windows-386/jvms.exe
 
-      - name: compression zip
+      - name: Create ZIP archives
         run: |
-          hash=`git rev-list --tags --max-count=1`
-          version=`git describe --tags $hash`
+          hash=$(git rev-list --tags --max-count=1)
+          version=$(git describe --tags $hash)
           zip -j jvms_${version}_amd64.zip build/windows-amd64/jvms.exe
           zip -j jvms_${version}_386.zip   build/windows-386/jvms.exe
 
-      - name: Upload release binaries
-        uses: alexellis/upload-assets@0.2.2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
         with:
-          asset_paths: '["./jvms_*.zip"]'
+          files: |
+            jvms_*_amd64.zip
+            jvms_*_386.zip


### PR DESCRIPTION
Enhance and modernize the GitHub Actions workflow for building and releasing Go binaries:

- 🔧 Add 'contents: write' permission to the workflow for better release handling.
- ⬆️ Upgrade actions/setup-go from v2 to v5 and update Go version to 1.23 with check-latest enabled.
- ⬆️ Upgrade actions/checkout from v2 to v4 and set fetch-depth to 0 for full repository history.
- 🛠️ Replace backticks with  for command substitution in shell scripts for better readability and consistency.
- 🗜️ Rename and improve the ZIP creation step for clarity (compression zip -> Create ZIP archives).
- 🚀 Replace alexellis/upload-assets with softprops/action-gh-release@v1 for uploading release assets.
  - Specify release asset files using a more flexible and readable format.

These changes improve the maintainability, compatibility, and functionality of the build workflow.