### PR TITLE
Fix: Passing cfx by value was a mistake

### DIFF
--- a/internal/cmdCli/switch.go
+++ b/internal/cmdCli/switch.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/ystyle/jvms/internal/entity"
@@ -26,7 +27,7 @@ func switch_(cfx *entity.Config) *cli.Command {
 
 func switchFunc(cfx entity.Config) func(*cli.Context) error {
 	return func(c *cli.Context) error {
-		v := c.Args().Get(0)
+		v := strings.TrimSpace(c.Args().Get(0))
 		if v == "" {
 			return errors.New("you should input a version or index number, Type \"jvms list\" to see what is installed")
 		}

--- a/internal/cmdCli/switch.go
+++ b/internal/cmdCli/switch.go
@@ -20,12 +20,12 @@ func switch_(cfx *entity.Config) *cli.Command {
 		Name:      "switch",
 		ShortName: "s",
 		Usage:     "Switch to use the specified version or index number.",
-		Action:    switchFunc(*cfx),
+		Action:    switchFunc(cfx),
 	}
 	return cmd
 }
 
-func switchFunc(cfx entity.Config) func(*cli.Context) error {
+func switchFunc(cfx *entity.Config) func(*cli.Context) error {
 	return func(c *cli.Context) error {
 		v := strings.TrimSpace(c.Args().Get(0))
 		if v == "" {

--- a/internal/cmdCli/switch.go
+++ b/internal/cmdCli/switch.go
@@ -25,6 +25,7 @@ func switch_(cfx *entity.Config) *cli.Command {
 	return cmd
 }
 
+// SwitchFunc is used by both switch and use commands
 func switchFunc(cfx *entity.Config) func(*cli.Context) error {
 	return func(c *cli.Context) error {
 		v := strings.TrimSpace(c.Args().Get(0))

--- a/internal/cmdCli/use.go
+++ b/internal/cmdCli/use.go
@@ -10,7 +10,7 @@ func use(cfx *entity.Config) *cli.Command {
 		Name:      "use",
 		ShortName: "u",
 		Usage:     "Switch to use the specified version or index number.",
-		Action:    switchFunc(*cfx),
+		Action:    switchFunc(cfx),
 	}
 	return cmd
 }

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ const (
 	defaultOriginalpath = "https://raw.githubusercontent.com/ystyle/jvms/new/jdkdlindex.json"
 )
 
-var cfx entity.Config
+var cfx *entity.Config
 
 func main() {
 	app := cli.NewApp()
@@ -42,7 +42,7 @@ func main() {
 func commands() []cli.Command {
 	cmds := cmdCli.Commands(&cmdCli.CommandParams{
 		DefaultOriginalPath: defaultOriginalpath,
-		Config:              &cfx,
+		Config:              cfx,
 	})
 	return cmds
 }

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ const (
 	defaultOriginalpath = "https://raw.githubusercontent.com/ystyle/jvms/new/jdkdlindex.json"
 )
 
-var cfx *entity.Config
+var cfx = &entity.Config{}
 
 func main() {
 	app := cli.NewApp()


### PR DESCRIPTION
Passing cfx by value was a mistake. It was fixed by passing cfx as a reference. Switch command's args whitespace linted.