### PR TITLE
Minor fixes, added 'storepath' file flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor
 download
+storepath
 store
 *.exe
 .idea

--- a/internal/cmdCli/cmds.go
+++ b/internal/cmdCli/cmds.go
@@ -5,21 +5,20 @@ import (
 	"github.com/ystyle/jvms/internal/entity"
 )
 
-type CommandParams struct {
-	DefaultOriginalPath string
-	Config              *entity.Config
-}
+const (
+	DefaultOriginalpath = "https://raw.githubusercontent.com/ystyle/jvms/new/jdkdlindex.json"
+)
 
-func Commands(cp *CommandParams) []cli.Command {
-	cmds := []cli.Command{
-		*init_(cp.DefaultOriginalPath, cp.Config),
-		*list(cp.Config),
-		*install(cp.Config),
-		*switch_(cp.Config),
-		*use(cp.Config),
-		*remove(cp.Config),
-		*rls(cp.Config),
-		*proxy(cp.Config),
+// Commands Registrer
+func Commands(c *entity.Config) []cli.Command {
+	return []cli.Command{
+		*switch_(c),
+		*install(c),
+		*remove(c),
+		*init_(c),
+		*proxy(c),
+		*list(c),
+		*use(c),
+		*rls(c),
 	}
-	return cmds
 }

--- a/internal/cmdCli/init.go
+++ b/internal/cmdCli/init.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ystyle/jvms/utils/file"
 )
 
-func init_(defaultOriginalpath string, config *entity.Config) *cli.Command {
+func init_(config *entity.Config) *cli.Command {
 	return &cli.Command{
 		Name:        "init",
 		Usage:       "Initialize config file",
@@ -26,7 +26,7 @@ func init_(defaultOriginalpath string, config *entity.Config) *cli.Command {
 			cli.StringFlag{
 				Name:  "originalpath",
 				Usage: "the jdk download index file url.",
-				Value: defaultOriginalpath,
+				Value: DefaultOriginalpath,
 			},
 		},
 		Action: func(c *cli.Context) error {

--- a/internal/cmdCli/install.go
+++ b/internal/cmdCli/install.go
@@ -23,6 +23,15 @@ func install(config *entity.Config) *cli.Command {
 	return cmd
 }
 
+func installPrerequisites(config *entity.Config) {
+	if !file.Exists(config.Download) {
+		os.MkdirAll(config.Download, 0777)
+	}
+	if !file.Exists(config.Store) {
+		os.MkdirAll(config.Store, 0777)
+	}
+}
+
 func installFunc(config *entity.Config) func(*cli.Context) error {
 	return func(c *cli.Context) error {
 		if config.Proxy != "" {
@@ -42,13 +51,7 @@ func installFunc(config *entity.Config) func(*cli.Context) error {
 			return err
 		}
 
-		if !file.Exists(config.Download) {
-			os.MkdirAll(config.Download, 0777)
-		}
-		if !file.Exists(config.Store) {
-			os.MkdirAll(config.Store, 0777)
-		}
-
+		installPrerequisites(config)
 		for _, version := range versions {
 			if version.Version == v {
 				dlzipfile, success := web.GetJDK(config.Download, v, version.Url)

--- a/main.go
+++ b/main.go
@@ -17,10 +17,6 @@ import (
 
 var version = "2.1.0"
 
-const (
-	defaultOriginalpath = "https://raw.githubusercontent.com/ystyle/jvms/new/jdkdlindex.json"
-)
-
 var config = &entity.Config{}
 
 func main() {
@@ -29,7 +25,7 @@ func main() {
 	app.Usage = `JDK Version Manager (JVMS) for Windows`
 	app.Version = version
 	app.CommandNotFound = commandNotFound
-	app.Commands = commands()
+	app.Commands = cmdCli.Commands(config)
 
 	app.Before = startup
 	app.After = shutdown
@@ -37,14 +33,6 @@ func main() {
 		log.Fatal(err.Error())
 		os.Exit(1)
 	}
-}
-
-func commands() []cli.Command {
-	cmds := cmdCli.Commands(&cmdCli.CommandParams{
-		DefaultOriginalPath: defaultOriginalpath,
-		Config:              config,
-	})
-	return cmds
 }
 
 func commandNotFound(c *cli.Context, command string) {
@@ -68,7 +56,7 @@ func startup(c *cli.Context) error {
 
 	config.Download = filepath.Join(s, "download")
 	if config.Originalpath == "" {
-		config.Originalpath = defaultOriginalpath
+		config.Originalpath = cmdCli.DefaultOriginalpath
 	}
 	if config.Proxy != "" {
 		web.SetProxy(config.Proxy)

--- a/main.go
+++ b/main.go
@@ -15,9 +15,10 @@ import (
 	"github.com/ystyle/jvms/utils/web"
 )
 
-var version = "2.1.0"
-
-var config = &entity.Config{}
+var (
+	version = "2.1.0"
+	config  = &entity.Config{}
+)
 
 func main() {
 	app := cli.NewApp()

--- a/main.go
+++ b/main.go
@@ -53,8 +53,12 @@ func startup(c *cli.Context) error {
 		return errors.New("failed to load the config:" + err.Error())
 	}
 	s := file.GetCurrentPath()
-	config.Store = filepath.Join(s, "store")
 
+	config.Store = filepath.Join(s, "store")
+	// Override store path by storepath file
+	if storepath, err := os.ReadFile(filepath.Join(s, "storepath")); err == nil {
+		config.Store = string(storepath)
+	}
 	config.Download = filepath.Join(s, "download")
 	if config.Originalpath == "" {
 		config.Originalpath = cmdCli.DefaultOriginalpath


### PR DESCRIPTION
Minor fixes: cmdCli was simplified, and the main file

Added storepath flag that allows override of the store path
Example storepath (note, no extension) file contents: C:\jdks