### PR TITLE
Fix: invalidate cache race & cleanup

### DIFF
--- a/internal/icli/rels.go
+++ b/internal/icli/rels.go
@@ -23,8 +23,9 @@ func rls(config *models.Config) *cli.Command {
 			if config.Proxy != "" {
 				web.SetProxy(config.Proxy)
 			}
-			jdk.InvalidateCache()
-			fmt.Println("Fetching available JDK versions...")
+			if err := jdk.InvalidateCache(config); err != nil {
+				return err
+			}
 			versions, err := jdk.GetJdkVersions(config)
 			if err != nil {
 				return err

--- a/internal/ui/dialog.go
+++ b/internal/ui/dialog.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"strings"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 const (
@@ -9,6 +11,7 @@ const (
 	fallbackHelpStyle = "press enter to exit"
 )
 
+// dialog.go — wrap the rendered dialog in Place using the model's known size
 func (m *pickerModel) newDialog(text, help string) string {
 	var b strings.Builder
 	b.WriteString(titleStyle.Render(m.action.Title))
@@ -22,5 +25,10 @@ func (m *pickerModel) newDialog(text, help string) string {
 		b.WriteString(helpStyle.Render(help))
 	}
 
-	return dialogStyle.Render(b.String())
+	box := dialogStyle.Render(b.String())
+
+	if m.width == 0 || m.height == 0 {
+		return box // no size known yet (e.g. first frame) — fall back ungracefully
+	}
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }

--- a/internal/ui/dialog.go
+++ b/internal/ui/dialog.go
@@ -11,7 +11,7 @@ const (
 	fallbackHelpStyle = "press enter to exit"
 )
 
-// dialog.go — wrap the rendered dialog in Place using the model's known size
+// dialog.go, wrap the rendered dialog in Place using the model's known size
 func (m *pickerModel) newDialog(text, help string) string {
 	var b strings.Builder
 	b.WriteString(titleStyle.Render(m.action.Title))
@@ -28,7 +28,7 @@ func (m *pickerModel) newDialog(text, help string) string {
 	box := dialogStyle.Render(b.String())
 
 	if m.width == 0 || m.height == 0 {
-		return box // no size known yet (e.g. first frame) — fall back ungracefully
+		return box // no size known yet (e.g. first frame) so fall back ungracefully
 	}
 	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, box)
 }

--- a/internal/ui/global.go
+++ b/internal/ui/global.go
@@ -1,0 +1,35 @@
+package ui
+
+import (
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// globalFunc handles messages that apply regardless of state (quit,
+// spinner ticks, resize). It returns handled=true if it fully processed
+// the message, so Update should stop and return immediately.
+func (m *pickerModel) globalFunc(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
+	switch tm := msg.(type) {
+	case tea.KeyMsg:
+		if tm.String() == "ctrl+c" {
+			return m, tea.Quit, true
+		}
+
+	case spinner.TickMsg:
+		if !m.spinnerActive {
+			return m, nil, true // stale tick from a state we've already left
+		}
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(tm)
+		return m, cmd, true
+
+	case tea.WindowSizeMsg:
+		m.width, m.height = tm.Width, tm.Height
+		h, v := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
+		m.list.SetSize(tm.Width-h, tm.Height-v)
+		return m, nil, true
+	}
+
+	return m, nil, false
+}

--- a/internal/ui/global.go
+++ b/internal/ui/global.go
@@ -6,6 +6,18 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
+type subModelUpdate[T any] interface {
+	Update(tea.Msg) (T, tea.Cmd)
+}
+
+// updateSubModel drives any subModel-shaped component, writes the result
+// back into *component, and hands back the tea.Cmd to propagate.
+func updateSubModel[T subModelUpdate[T]](component *T, msg tea.Msg) tea.Cmd {
+	newComp, cmd := (*component).Update(msg)
+	*component = newComp
+	return cmd
+}
+
 // globalFunc handles messages that apply regardless of state (quit,
 // spinner ticks, resize). It returns handled=true if it fully processed
 // the message, so Update should stop and return immediately.
@@ -20,9 +32,7 @@ func (m *pickerModel) globalFunc(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 		if !m.spinnerActive {
 			return m, nil, true // stale tick from a state we've already left
 		}
-		var cmd tea.Cmd
-		m.spinner, cmd = m.spinner.Update(tm)
-		return m, cmd, true
+		return m, updateSubModel(&m.spinner, tm), true
 
 	case tea.WindowSizeMsg:
 		m.width, m.height = tm.Width, tm.Height

--- a/internal/ui/global.go
+++ b/internal/ui/global.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 type subModelUpdate[T any] interface {
@@ -36,8 +35,7 @@ func (m *pickerModel) globalFunc(msg tea.Msg) (tea.Model, tea.Cmd, bool) {
 
 	case tea.WindowSizeMsg:
 		m.width, m.height = tm.Width, tm.Height
-		h, v := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
-		m.list.SetSize(tm.Width-h, tm.Height-v)
+		m.list.SetSize(tm.Width, tm.Height)
 		return m, nil, true
 	}
 

--- a/internal/ui/list.go
+++ b/internal/ui/list.go
@@ -15,6 +15,7 @@ func (m *pickerModel) listFunc(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, updateSubModel(&m.list, msg)
 
 	}
+	// Unhandled keys fall through to the list for navigation, filtering, and help.
 	switch km.String() {
 	case "q":
 		return m, tea.Quit

--- a/internal/ui/list.go
+++ b/internal/ui/list.go
@@ -12,22 +12,19 @@ func (m *pickerModel) listView() string {
 func (m *pickerModel) listFunc(msg tea.Msg) (tea.Model, tea.Cmd) {
 	km, ok := msg.(tea.KeyMsg)
 	if !ok || m.list.FilterState() == bubbleView.Filtering {
-		var cmd tea.Cmd
-		m.list, cmd = m.list.Update(msg)
-		return m, cmd
+		return m, updateSubModel(&m.list, msg)
+
 	}
 	switch km.String() {
 	case "q":
 		return m, tea.Quit
 	case "enter":
 		if it, ok := m.list.SelectedItem().(jdkItem); ok {
-			cmd := m.selectItem(it.JdkVersion)
-			return m, cmd
+			return m, m.selectItem(it.JdkVersion)
 		}
 		// filter matched zero items -> nothing to select, ignore
 		return m, nil
 	}
-	var cmd tea.Cmd
-	m.list, cmd = m.list.Update(msg)
-	return m, cmd
+
+	return m, updateSubModel(&m.list, msg)
 }

--- a/internal/ui/picker.go
+++ b/internal/ui/picker.go
@@ -10,7 +10,7 @@ import (
 
 type jdkItem struct{ models.JdkVersion }
 
-func (i jdkItem) Title() string       { return i.Version }
+func (i jdkItem) Title() string { return i.Version }
 func (i jdkItem) Description() string {
 	if i.Url != "" {
 		return i.Url
@@ -29,8 +29,9 @@ type pickerModel struct {
 	spinner       spinner.Model
 	spinnerActive bool
 
-	selected models.JdkVersion
-	err      error // set only on execute failure
+	width, height int // terminal size
+	selected      models.JdkVersion
+	err           error // set only on execute failure
 }
 
 const (

--- a/internal/ui/picker.go
+++ b/internal/ui/picker.go
@@ -42,10 +42,16 @@ const (
 	stateDone
 )
 
-// RunJdkPicker starts the picker TUI over the given versions and blocks
+// RunJdkPicker starts the picker TUI over the given versions and blocks.
 func RunJdkPicker(config *models.Config, versions []models.JdkVersion, action Action) error {
-	_, err := tea.NewProgram(newPickerModel(config, versions, action), tea.WithAltScreen()).Run()
-	return err
+	finalModel, err := tea.NewProgram(newPickerModel(config, versions, action), tea.WithAltScreen()).Run()
+	if err != nil {
+		return err
+	}
+	if pm, ok := finalModel.(*pickerModel); ok {
+		return pm.err
+	}
+	return nil
 }
 
 func newPickerModel(config *models.Config, versions []models.JdkVersion, action Action) *pickerModel {

--- a/internal/ui/picker.go
+++ b/internal/ui/picker.go
@@ -55,6 +55,10 @@ func RunJdkPicker(config *models.Config, versions []models.JdkVersion, action Ac
 }
 
 func newPickerModel(config *models.Config, versions []models.JdkVersion, action Action) *pickerModel {
+	if action.Execute == nil || action.SuccessText == nil {
+		panic("ui: Action.Execute and Action.SuccessText are required")
+	}
+
 	l := bubbleView.New(nil, bubbleView.NewDefaultDelegate(), 0, 0)
 	l.Title = action.Title
 	l.SetFilteringEnabled(true)

--- a/internal/ui/routing.go
+++ b/internal/ui/routing.go
@@ -1,9 +1,7 @@
 package ui
 
 import (
-	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 // View renders the current state of the picker model to a string for display in the terminal.
@@ -24,23 +22,8 @@ func (m *pickerModel) View() string {
 }
 
 func (m *pickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if km, ok := msg.(tea.KeyMsg); ok && km.String() == "ctrl+c" {
-		return m, tea.Quit
-	}
-
-	if tm, ok := msg.(spinner.TickMsg); ok {
-		if !m.spinnerActive {
-			return m, nil // stale tick from a state we've already left
-		}
-		var cmd tea.Cmd
-		m.spinner, cmd = m.spinner.Update(tm)
-		return m, cmd
-	}
-
-	if wm, ok := msg.(tea.WindowSizeMsg); ok {
-		h, v := lipgloss.NewStyle().Margin(1, 2).GetFrameSize()
-		m.list.SetSize(wm.Width-h, wm.Height-v)
-		return m, nil
+	if model, cmd, handled := m.globalFunc(msg); handled {
+		return model, cmd
 	}
 
 	switch m.state {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -13,10 +13,16 @@ const (
 )
 
 var (
-	titleStyle  = lipgloss.NewStyle().Bold(true).Foreground(colorAccent)
-	dialogStyle = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).
-			BorderForeground(colorAccent).Padding(1, 2)
+	titleStyle   = lipgloss.NewStyle().Bold(true).Foreground(colorAccent)
 	errStyle     = lipgloss.NewStyle().Foreground(colorError)
 	successStyle = lipgloss.NewStyle().Foreground(colorSuccess)
 	helpStyle    = lipgloss.NewStyle().Foreground(colorMuted)
+	dialogStyle  = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorAccent).
+			Padding(1, 2).
+			Width(48).                        // fixed width keeps it from jittering per-message
+			Height(7).                        // min height, lipgloss pads short content to fill it
+			AlignHorizontal(lipgloss.Center). // center text/help lines inside the box
+			AlignVertical(lipgloss.Center)
 )

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -17,8 +17,7 @@ var (
 	errStyle     = lipgloss.NewStyle().Foreground(colorError)
 	successStyle = lipgloss.NewStyle().Foreground(colorSuccess)
 	helpStyle    = lipgloss.NewStyle().Foreground(colorMuted)
-	dialogStyle  = lipgloss.NewStyle().
-			Border(lipgloss.RoundedBorder()).
+	dialogStyle  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).
 			BorderForeground(colorAccent).
 			Padding(1, 2).
 			Width(48).                        // fixed width keeps it from jittering per-message

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -9,7 +9,7 @@ const (
 	colorSuccess = lipgloss.Color("108") // muted sage green
 	colorError   = lipgloss.Color("203") // soft coral red
 	colorMuted   = lipgloss.Color("245") // help text, secondary info
-	colorDim     = lipgloss.Color("238") // faint borders, disabled state
+	// colorDim     = lipgloss.Color("238") // faint borders, disabled state
 )
 
 var (

--- a/utils/jdk/cache.go
+++ b/utils/jdk/cache.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	cacheFileName = "jdk_versions.json"
-	cacheTTL      = 24 * 60 * 60 // Cache time-to-live in seconds (24 hours)
+	cacheFileName    = "jdk_versions.json"
+	cacheTTL         = 24 * 60 * 60 // Cache time-to-live in seconds (24 hours)
+	cacheFetchWindow = 60 * 5       // Recently refreshed window (5 minutes)
 )
 
 type JdkVersionCache struct {
@@ -18,7 +19,16 @@ type JdkVersionCache struct {
 	LastUpdated int64               `json:"last_updated"`
 }
 
-func InvalidateCache() error {
+func InvalidateCache(config *models.Config) error {
+	getJdkLock.Lock()
+	defer getJdkLock.Unlock()
+
+	_, recentlyFetched, err := loadCachedJdkVersions(config)
+	if err == nil && recentlyFetched {
+		// Cache was refreshed very recently; don't throw it away.
+		return nil
+	}
+
 	return store.Save(cacheFileName, &JdkVersionCache{})
 }
 
@@ -33,16 +43,19 @@ func cacheJdkVersions(config *models.Config, versions []models.JdkVersion) error
 	})
 }
 
-func loadCachedJdkVersions(config *models.Config) ([]models.JdkVersion, error) {
+// loadCachedJdkVersions returns the cached versions and whether the cache was
+// refreshed recently.
+func loadCachedJdkVersions(config *models.Config) ([]models.JdkVersion, bool, error) {
 	versionsCached := &JdkVersionCache{}
 	if err := store.Load(cacheFileName, versionsCached); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	// Check if the cache is still valid based on TTL
-	if time.Now().Unix()-versionsCached.LastUpdated > cacheTTL {
-		return nil, errors.New("cached JDK versions are stale")
+	age := time.Now().Unix() - versionsCached.LastUpdated
+
+	if age > cacheTTL {
+		return nil, age <= cacheFetchWindow, errors.New("cached JDK versions are stale")
 	}
 
-	return versionsCached.Versions, nil
+	return versionsCached.Versions, age <= cacheFetchWindow, nil
 }

--- a/utils/jdk/jdk.go
+++ b/utils/jdk/jdk.go
@@ -59,10 +59,11 @@ func GetJdkVersions(config *models.Config) ([]models.JdkVersion, error) {
 	getJdkLock.Lock() // Ensure that only one goroutine can fetch JDK versions at a time
 	defer getJdkLock.Unlock()
 
-	if versions, err := loadCachedJdkVersions(config); err == nil {
+	if versions, _, err := loadCachedJdkVersions(config); err == nil {
 		return versions, nil
 	}
 
+	fmt.Println("Fetching available JDK versions...")
 	jsonContent, err := web.GetRemoteTextFile(config.OriginalPath)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Thank you for taking the time to review the last pr! I have made most of the changes you asked for before the previous merge.

Invalidate cache now uses the shared getJdkLock. The background preloader will block first, as it runs on startup. If the user uses the rls command, rls will try to invalidate the cache, but the cache now has a recently fetched window for the invalidate cache window to ignore. This results in the user waiting for the same background preloader to complete, and then reusing the fresh JDK versions